### PR TITLE
cmd: estclient: flags: Remove path formatting from rootOutFlag

### DIFF
--- a/cmd/estclient/flags.go
+++ b/cmd/estclient/flags.go
@@ -211,7 +211,6 @@ var optDefs = map[string]option{
 		defaultValue: "",
 	},
 	rootOutFlag: {
-		argFmt:       pathFmt,
 		desc:         "output root CA certificate only",
 		defaultValue: false,
 	},


### PR DESCRIPTION
`rootOutFlag` is just a boolean flag and does not accept a path.