### PR TITLE
cacerts - support individual file per CA

### DIFF
--- a/cmd/estclient/cacerts.go
+++ b/cmd/estclient/cacerts.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"log"
 
 	"github.com/globalsign/pemfile"
@@ -65,6 +66,9 @@ func cacerts(w io.Writer, set *flag.FlagSet) error {
 	if prefix := cfg.FlagValue(separateOutFlag); len(prefix) > 0 {
 		var filename string
 		subca_idx := 1
+
+		// sort by NotBefore to provide a predictable and stable index
+		sort.SliceStable(certs, func(i, j int) bool { return certs[i].NotBefore.Before(certs[j].NotBefore) })
 
 		for _, cert := range certs {
 			if cert == root {

--- a/cmd/estclient/commands.go
+++ b/cmd/estclient/commands.go
@@ -97,6 +97,7 @@ func init() {
 				outFlag,
 				passwordFlag,
 				rootOutFlag,
+				separateOutFlag,
 				separatorFlag,
 				serverFlag,
 				usernameFlag,

--- a/cmd/estclient/flags.go
+++ b/cmd/estclient/flags.go
@@ -83,6 +83,7 @@ const (
 	postalCodeFlag         = "postalcode"
 	provinceFlag           = "province"
 	rootOutFlag            = "rootout"
+	separateOutFlag        = "sepout"
 	separatorFlag          = "separator"
 	serialNumberFlag       = "sn"
 	serverFlag             = "server"
@@ -213,6 +214,12 @@ var optDefs = map[string]option{
 	rootOutFlag: {
 		desc:         "output root CA certificate only",
 		defaultValue: false,
+	},
+	separateOutFlag: {
+		argFmt:       stringFmt,
+		defaultLabel: "none",
+		desc:         "write every CA to a separete file with a given prefix",
+		defaultValue: "",
 	},
 	separatorFlag: {
 		argFmt:       stringFmt,


### PR DESCRIPTION
It is often required to have every CA certificate in its own file,
so instead of splitting them manually (which is clunky) - provide this option.

A new flag, `sepout`, enables this mode and sets a prefix for the filename
which are formatted according to the following:

    <prefix>-ca-root.pem - for root CA
    <prefix>-ca-<index>.pem - for subordinate CA, where index is based on ascending order of NotBefore