### PR TITLE
cacerts - support individual file per CA, more flexible filtering

### DIFF
--- a/cmd/estclient/cacerts.go
+++ b/cmd/estclient/cacerts.go
@@ -39,6 +39,18 @@ func cacerts(w io.Writer, set *flag.FlagSet) error {
 		}
 	}()
 
+	// make sure adequate set of filtering flags was passed
+	numberOfFilterFlagsSet := 0
+	filterFlags := []bool{cfg.FlagWasPassed(rootsOnlyFlag), cfg.FlagWasPassed(intermediatesOnlyFlag), cfg.FlagWasPassed(rootOutFlag)}
+	for _, flag := range filterFlags {
+		if flag {
+			numberOfFilterFlagsSet++
+		}
+	}
+	if numberOfFilterFlagsSet > 1 {
+		return fmt.Errorf("only one of -%s, -%s and -%s may be specified", rootsOnlyFlag, intermediatesOnlyFlag, rootOutFlag)
+	}
+
 	client, err := cfg.MakeClient()
 	if err != nil {
 		return fmt.Errorf("failed to make EST client: %v", err)
@@ -52,18 +64,30 @@ func cacerts(w io.Writer, set *flag.FlagSet) error {
 		return fmt.Errorf("failed to get CA certificates: %v", err)
 	}
 
-	if cfg.FlagWasPassed(rootOutFlag) {
-		var root *x509.Certificate
+	// filter certificates if requested
+	if numberOfFilterFlagsSet == 1 {
+		var roots, intermediates []*x509.Certificate
+
 		for _, cert := range certs {
 			if bytes.Equal(cert.RawSubject, cert.RawIssuer) && cert.CheckSignatureFrom(cert) == nil {
-				root = cert
-				break
+				roots = append(roots, cert)
+				if cfg.FlagWasPassed(rootOutFlag) {
+					break
+				}
+			} else {
+				intermediates = append(intermediates, cert)
 			}
 		}
-		if root == nil {
-			return errors.New("failed to find a root certificate in CA certificates")
+
+		if cfg.FlagWasPassed(rootsOnlyFlag) || cfg.FlagWasPassed(rootOutFlag) {
+			certs = roots
+		} else if cfg.FlagWasPassed(intermediatesOnlyFlag) {
+			certs = intermediates
 		}
-		certs = []*x509.Certificate{root}
+	}
+
+	if cfg.FlagWasPassed(rootOutFlag) && len(certs) == 0 {
+		return errors.New("failed to find a root certificate in CA certificates")
 	}
 
 	out, closeFunc, err := maybeRedirect(w, cfg.FlagValue(outFlag), 0666)

--- a/cmd/estclient/commands.go
+++ b/cmd/estclient/commands.go
@@ -97,6 +97,8 @@ func init() {
 				outFlag,
 				passwordFlag,
 				rootOutFlag,
+				rootsOnlyFlag,
+				intermediatesOnlyFlag,
 				separatorFlag,
 				serverFlag,
 				usernameFlag,

--- a/cmd/estclient/commands.go
+++ b/cmd/estclient/commands.go
@@ -95,6 +95,7 @@ func init() {
 				insecureFlag,
 				keyFlag,
 				outFlag,
+				separateOutFlag,
 				passwordFlag,
 				rootOutFlag,
 				rootsOnlyFlag,

--- a/cmd/estclient/flags.go
+++ b/cmd/estclient/flags.go
@@ -83,6 +83,8 @@ const (
 	postalCodeFlag         = "postalcode"
 	provinceFlag           = "province"
 	rootOutFlag            = "rootout"
+	rootsOnlyFlag          = "roots"
+	intermediatesOnlyFlag  = "intermediates"
 	separatorFlag          = "separator"
 	serialNumberFlag       = "sn"
 	serverFlag             = "server"
@@ -211,7 +213,15 @@ var optDefs = map[string]option{
 		defaultValue: "",
 	},
 	rootOutFlag: {
-		desc:         "output root CA certificate only",
+		desc:         fmt.Sprintf("output the first root CA certificate only; this flag will be deprecated in favor of -%s, which is preferred", rootsOnlyFlag),
+		defaultValue: false,
+	},
+	rootsOnlyFlag: {
+		desc:         "only output root (self-signed) certificates",
+		defaultValue: false,
+	},
+	intermediatesOnlyFlag: {
+		desc:         "only output intermediate certificates",
 		defaultValue: false,
 	},
 	separatorFlag: {

--- a/cmd/estclient/flags.go
+++ b/cmd/estclient/flags.go
@@ -79,6 +79,7 @@ const (
 	organizationFlag       = "org"
 	organizationalUnitFlag = "ou"
 	outFlag                = "out"
+	separateOutFlag        = "separate"
 	passwordFlag           = "pass"
 	postalCodeFlag         = "postalcode"
 	provinceFlag           = "province"
@@ -205,6 +206,10 @@ var optDefs = map[string]option{
 		defaultLabel: "stdout",
 		desc:         "output file",
 		defaultValue: "",
+	},
+	separateOutFlag: {
+		desc:         fmt.Sprintf("write every CA certificate to a separate file with optional prefix specified by -%s", outFlag),
+		defaultValue: false,
 	},
 	passwordFlag: {
 		argFmt:       stringFmt,


### PR DESCRIPTION
This implements two features - more flexible output filtering and
writing CA certs to individual files.

1. Flexible output filtering
    Using one of `roots` or `intermediates` flags allows the user to output
    only root or intermediate CA certificates respectively.
    
    In contrast with `rootout` flag,
    `roots` flag also supports outputting multiple root certificates.
    
    Note, that by 'root certificate' we understand 'self-issued certificate'
    as defined by RFC 5280 since this allows for inclusion of all certificates
    issued according to "Root CA Key Update" procedure
    as defined in Section 4.4 of RFC 4210.
    
    `rootout` flag was removed in favor of `roots` flag.

2. Writing every CA cert to separate file:
    
    A new flag, `separate`, enables this mode.
    It is possible to set filename prefix with `out` flag.
    Files are written in a format `<prefix>-<index>.pem`,
    `ca` is the default prefix, prefix can also end with `.pem`.

TODO:
- [ ] Update README