### PR TITLE
Custom HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,11 @@
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/globalsign/est/compare/v1.0.6...HEAD
-[1.0.6]: https://github.com/globalsign/est/compare/v1.0.5...v1.0.6
-[1.0.5]: https://github.com/globalsign/est/compare/v1.0.4...v1.0.5
-[1.0.4]: https://github.com/globalsign/est/compare/v1.0.3...v1.0.4
-[1.0.3]: https://github.com/globalsign/est/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/globalsign/est/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/globalsign/est/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/globalsign/est/releases/tag/v1.0.0
+[Unreleased]: https://github.com/haritzsaiz/est/compare/v1.0.6...HEAD
+[1.0.6]: https://github.com/haritzsaiz/est/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/haritzsaiz/est/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/haritzsaiz/est/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/haritzsaiz/est/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/haritzsaiz/est/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/haritzsaiz/est/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/haritzsaiz/est/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # est
 
-[![GoDoc](https://godoc.org/github.com/globalsign/est?status.svg)](https://godoc.org/github.com/globalsign/est)
-[![Build Status](https://github.com/globalsign/est/actions/workflows/go.yml/badge.svg)](https://github.com/globalsign/est/actions/workflows/go.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/globalsign/est)](https://goreportcard.com/report/github.com/globalsign/est)
+[![GoDoc](https://godoc.org/github.com/haritzsaiz/est?status.svg)](https://godoc.org/github.com/haritzsaiz/est)
+[![Build Status](https://github.com/haritzsaiz/est/actions/workflows/go.yml/badge.svg)](https://github.com/haritzsaiz/est/actions/workflows/go.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/haritzsaiz/est)](https://goreportcard.com/report/github.com/haritzsaiz/est)
 
 An implementation of the Enrollment over Secure Transport (EST) certificate
 enrollment protocol as defined by [RFC7030](https://tools.ietf.org/html/rfc7030).
@@ -30,8 +30,8 @@ section 24 of the Trusted Platform Module 2.0 Library specification.
 
 ## Installation
 
-    go install github.com/globalsign/est/cmd/estserver@latest
-    go install github.com/globalsign/est/cmd/estclient@latest
+    go install github.com/haritzsaiz/est/cmd/estserver@latest
+    go install github.com/haritzsaiz/est/cmd/estclient@latest
 
 ## Quickstart
 

--- a/client.go
+++ b/client.go
@@ -51,6 +51,29 @@ type Client struct {
 	// service for multiple CAs. See RFC7030 3.2.2.
 	AdditionalPathSegment string
 
+	// AdditionalHeaders are additional HTTP headers to include with the
+	// request to the EST server.
+	AdditionalHeaders map[string]string
+
+	// HostHeader overrides the default Host header for the HTTP request to the
+	// EST server, and is mostly useful for testing.
+	HostHeader string
+
+	// Username is an optional HTTP Basic Authentication username.
+	Username string
+
+	// Password is an optional HTTP Basic Authentication password.
+	Password string
+
+	// DisableKeepAlives disables HTTP keep-alives if set.
+	DisableKeepAlives bool
+
+	// http client used while performing EST operations. If nil, defaults to
+	// http.DefaultClient.
+	HttpClient *http.Client
+}
+
+type HttpClientBuilder struct {
 	// ExplicitAnchor is the optional Explicit TA database. See RFC7030 3.6.1.
 	ExplicitAnchor *x509.CertPool
 
@@ -69,20 +92,6 @@ type Client struct {
 	// support private keys resident on a hardware security module (HSM),
 	// Trusted Platform Module (TPM) or other hardware device.
 	PrivateKey interface{}
-
-	// AdditionalHeaders are additional HTTP headers to include with the
-	// request to the EST server.
-	AdditionalHeaders map[string]string
-
-	// HostHeader overrides the default Host header for the HTTP request to the
-	// EST server, and is mostly useful for testing.
-	HostHeader string
-
-	// Username is an optional HTTP Basic Authentication username.
-	Username string
-
-	// Password is an optional HTTP Basic Authentication password.
-	Password string
 
 	// DisableKeepAlives disables HTTP keep-alives if set.
 	DisableKeepAlives bool
@@ -104,6 +113,34 @@ const (
 	userAgent  = "GlobalSign EST Client " + estVersion + " github.com/globalsign/est"
 )
 
+func NewHttpClient(clientBuilder HttpClientBuilder) *http.Client {
+	var rootCAs *x509.CertPool
+	if clientBuilder.ExplicitAnchor != nil {
+		rootCAs = clientBuilder.ExplicitAnchor
+	} else if clientBuilder.ImplicitAnchor != nil {
+		rootCAs = clientBuilder.ImplicitAnchor
+	}
+
+	var tlsCerts []tls.Certificate
+	if len(clientBuilder.Certificates) > 0 && clientBuilder.PrivateKey != nil {
+		tlsCerts = []tls.Certificate{{PrivateKey: clientBuilder.PrivateKey, Leaf: clientBuilder.Certificates[0]}}
+		for i := range clientBuilder.Certificates {
+			tlsCerts[0].Certificate = append(tlsCerts[0].Certificate, clientBuilder.Certificates[i].Raw)
+		}
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:            rootCAs,
+				Certificates:       tlsCerts,
+				InsecureSkipVerify: clientBuilder.InsecureSkipVerify,
+			},
+			DisableKeepAlives: clientBuilder.DisableKeepAlives,
+		},
+	}
+}
+
 // CACerts requests a copy of the current CA certificates.
 func (c *Client) CACerts(ctx context.Context) ([]*x509.Certificate, error) {
 	req, err := c.newRequest(ctx, http.MethodGet, cacertsEndpoint, "", "", mimeTypePKCS7, nil)
@@ -111,7 +148,7 @@ func (c *Client) CACerts(ctx context.Context) ([]*x509.Certificate, error) {
 		return nil, err
 	}
 
-	resp, err := c.makeHTTPClient().Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
@@ -135,7 +172,7 @@ func (c *Client) CSRAttrs(ctx context.Context) (CSRAttrs, error) {
 		return CSRAttrs{}, err
 	}
 
-	resp, err := c.makeHTTPClient().Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return CSRAttrs{}, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
@@ -189,7 +226,7 @@ func (c *Client) enrollCommon(ctx context.Context, r *x509.CertificateRequest, r
 		return nil, err
 	}
 
-	resp, err := c.makeHTTPClient().Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
@@ -216,7 +253,7 @@ func (c *Client) ServerKeyGen(ctx context.Context, r *x509.CertificateRequest) (
 		return nil, nil, err
 	}
 
-	resp, err := c.makeHTTPClient().Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
@@ -350,7 +387,7 @@ func (c *Client) TPMEnroll(
 		return nil, nil, nil, err
 	}
 
-	resp, err := c.makeHTTPClient().Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}
@@ -538,34 +575,4 @@ func (c *Client) uri(endpoint string) string {
 	builder.WriteString(endpoint)
 
 	return builder.String()
-}
-
-// makeHTTPClient makes and configures an HTTP client for connecting to an
-// EST server.
-func (c *Client) makeHTTPClient() *http.Client {
-	var rootCAs *x509.CertPool
-	if c.ExplicitAnchor != nil {
-		rootCAs = c.ExplicitAnchor
-	} else if c.ImplicitAnchor != nil {
-		rootCAs = c.ImplicitAnchor
-	}
-
-	var tlsCerts []tls.Certificate
-	if len(c.Certificates) > 0 && c.PrivateKey != nil {
-		tlsCerts = []tls.Certificate{{PrivateKey: c.PrivateKey, Leaf: c.Certificates[0]}}
-		for i := range c.Certificates {
-			tlsCerts[0].Certificate = append(tlsCerts[0].Certificate, c.Certificates[i].Raw)
-		}
-	}
-
-	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs:            rootCAs,
-				Certificates:       tlsCerts,
-				InsecureSkipVerify: c.InsecureSkipVerify,
-			},
-			DisableKeepAlives: c.DisableKeepAlives,
-		},
-	}
 }

--- a/client.go
+++ b/client.go
@@ -47,6 +47,8 @@ type Client struct {
 	// component, e.g. est.server.com:8443
 	Host string
 
+	HttpProtocol string
+
 	// AdditionalPathSegment is an optional label for EST servers to provide
 	// service for multiple CAs. See RFC7030 3.2.2.
 	AdditionalPathSegment string
@@ -110,7 +112,7 @@ type HttpClientBuilder struct {
 // Client constants.
 const (
 	estVersion = "v1.0.6"
-	userAgent  = "GlobalSign EST Client " + estVersion + " github.com/globalsign/est"
+	userAgent  = "GlobalSign EST Client " + estVersion + " github.com/haritzsaiz/est"
 )
 
 func NewHttpClient(clientBuilder HttpClientBuilder) *http.Client {
@@ -563,7 +565,7 @@ func checkResponseError(r *http.Response) error {
 func (c *Client) uri(endpoint string) string {
 	var builder strings.Builder
 
-	builder.WriteString("https://")
+	builder.WriteString(fmt.Sprintf("%s://", c.HttpProtocol))
 	builder.WriteString(c.Host)
 	builder.WriteString(estPathPrefix)
 

--- a/cmd/estclient/config.go
+++ b/cmd/estclient/config.go
@@ -140,18 +140,22 @@ func (cfg *config) MakeContext() (context.Context, context.CancelFunc) {
 // makeClient builds an EST client from a configuration file, overriding the
 // values with command line options, if applicable.
 func (cfg *config) MakeClient() (*est.Client, error) {
+	httpCli := est.NewHttpClient(est.HttpClientBuilder{
+		ExplicitAnchor:     cfg.explicitAnchor,
+		ImplicitAnchor:     cfg.implicitAnchor,
+		PrivateKey:         cfg.openPrivateKey,
+		Certificates:       cfg.certificates,
+		InsecureSkipVerify: cfg.insecure,
+	})
+
 	client := est.Client{
 		Host:                  cfg.Server,
+		HttpClient:            httpCli,
 		AdditionalPathSegment: cfg.APS,
 		AdditionalHeaders:     cfg.AdditionalHeaders,
-		ExplicitAnchor:        cfg.explicitAnchor,
-		ImplicitAnchor:        cfg.implicitAnchor,
 		HostHeader:            cfg.HostHeader,
-		PrivateKey:            cfg.openPrivateKey,
-		Certificates:          cfg.certificates,
 		Username:              cfg.Username,
 		Password:              cfg.Password,
-		InsecureSkipVerify:    cfg.insecure,
 	}
 
 	// Host is the only required field for all operations.

--- a/cmd/estclient/config.go
+++ b/cmd/estclient/config.go
@@ -34,7 +34,7 @@ import (
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
-	"github.com/globalsign/est"
+	"github.com/haritzsaiz/est"
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/globalsign/pemfile"

--- a/cmd/estclient/config_test.go
+++ b/cmd/estclient/config_test.go
@@ -40,8 +40,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/globalsign/est"
-	"github.com/globalsign/est/internal/mockca"
+	"github.com/haritzsaiz/est"
+	"github.com/haritzsaiz/est/internal/mockca"
 
 	"github.com/globalsign/pemfile"
 )

--- a/cmd/estserver/main.go
+++ b/cmd/estserver/main.go
@@ -35,10 +35,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/globalsign/est"
-	"github.com/globalsign/est/internal/basiclogger"
-	"github.com/globalsign/est/internal/mockca"
 	"github.com/globalsign/pemfile"
+	"github.com/haritzsaiz/est"
+	"github.com/haritzsaiz/est/internal/basiclogger"
+	"github.com/haritzsaiz/est/internal/mockca"
 )
 
 const (

--- a/csrattrs_test.go
+++ b/csrattrs_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/globalsign/est"
+	"github.com/haritzsaiz/est"
 )
 
 func TestCSRAttrsMarshal(t *testing.T) {

--- a/est_test.go
+++ b/est_test.go
@@ -44,10 +44,10 @@ import (
 	"github.com/google/go-tpm/tpm2"
 	"go.mozilla.org/pkcs7"
 
-	"github.com/globalsign/est"
-	"github.com/globalsign/est/internal/basiclogger"
-	"github.com/globalsign/est/internal/mockca"
-	"github.com/globalsign/est/internal/tpm"
+	"github.com/haritzsaiz/est"
+	"github.com/haritzsaiz/est/internal/basiclogger"
+	"github.com/haritzsaiz/est/internal/mockca"
+	"github.com/haritzsaiz/est/internal/tpm"
 )
 
 // Test constants.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/globalsign/est
+module github.com/haritzsaiz/est
 
 go 1.13
 

--- a/internal/basiclogger/logger.go
+++ b/internal/basiclogger/logger.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/globalsign/est"
+	"github.com/haritzsaiz/est"
 )
 
 // Logger is a basic logger implementing est.Logger.

--- a/internal/basiclogger/logger_test.go
+++ b/internal/basiclogger/logger_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/globalsign/est/internal/basiclogger"
+	"github.com/haritzsaiz/est/internal/basiclogger"
 )
 
 func TestLogger(t *testing.T) {

--- a/internal/mockca/ca.go
+++ b/internal/mockca/ca.go
@@ -38,8 +38,8 @@ import (
 
 	"github.com/globalsign/pemfile"
 
-	"github.com/globalsign/est"
-	"github.com/globalsign/est/internal/tpm"
+	"github.com/haritzsaiz/est"
+	"github.com/haritzsaiz/est/internal/tpm"
 )
 
 // MockCA is a mock, non-production certificate authority useful for testing
@@ -87,9 +87,9 @@ func (ca *MockCA) CACerts(
 
 // CSRAttrs returns an empty sequence of CSR attributes, unless the additional
 // path segment is:
-//  - "csrattrs", in which case it returns the same example sequence described
-//    in RFC7030 4.5.2; or
-//  - "triggererrors", in which case an error is returned for testing purposes.
+//   - "csrattrs", in which case it returns the same example sequence described
+//     in RFC7030 4.5.2; or
+//   - "triggererrors", in which case an error is returned for testing purposes.
 func (ca *MockCA) CSRAttrs(
 	ctx context.Context,
 	aps string,

--- a/internal/mockca/ca_test.go
+++ b/internal/mockca/ca_test.go
@@ -32,10 +32,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/globalsign/est"
-	"github.com/globalsign/est/internal/mockca"
-	"github.com/globalsign/est/internal/tpm"
 	"github.com/google/go-tpm/tpm2"
+	"github.com/haritzsaiz/est"
+	"github.com/haritzsaiz/est/internal/mockca"
+	"github.com/haritzsaiz/est/internal/tpm"
 	"go.mozilla.org/pkcs7"
 )
 

--- a/internal/tpm/make_cred_test.go
+++ b/internal/tpm/make_cred_test.go
@@ -23,8 +23,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/globalsign/est/internal/tpm"
 	"github.com/google/go-tpm/tpm2"
+	"github.com/haritzsaiz/est/internal/tpm"
 )
 
 func TestMakeAndExtractCredential(t *testing.T) {


### PR DESCRIPTION
This allows using custom HTTP clients if needed (i.e, adding a custom HTTP Transport proxy/middleware to log requests).